### PR TITLE
selection.attr funct(d, index)

### DIFF
--- a/src/main/scala/Selection.scala
+++ b/src/main/scala/Selection.scala
@@ -84,6 +84,7 @@ object d3selection extends js.Object {
     def attr(name: String, value: Double): T = js.native
     def attr(name: String, value: Boolean): T = js.native
     def attr[R](name: String, value: ValueFunction1[R]): T = js.native
+    def attr[R](name: String, value: ValueFunction2[R]): T = js.native
 
     def text(): String = js.native
     def text(value: String): T = js.native


### PR DESCRIPTION
This adds support for a function which uses the current datum _d_ and the current index _i_ to `selection.attr`.
See [selection.attr doc](https://d3-wiki.readthedocs.io/zh_CN/master/Selections/#attr)

Example: https://www.d3indepth.com/selections/#updating-selections-with-functions