### PR TITLE
Initial Hierarchy Module with Pack Layout

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 name := "scala-js-d3v4"
+version := "master-SNAPSHOT"
 organization := "com.github.fdietze.scala-js-d3v4"
 
 crossScalaVersions := Seq("2.12.12", "2.13.3")

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 name := "scala-js-d3v4"
-version := "master-SNAPSHOT"
+version := "1.0.0-SNAPSHOT"
+organization := "com.github.fdietze.scala-js-d3v4"
 
 crossScalaVersions := Seq("2.12.12", "2.13.3")
 scalaVersion in ThisBuild := crossScalaVersions.value.last

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 name := "scala-js-d3v4"
-version := "1.0.0-SNAPSHOT"
 organization := "com.github.fdietze.scala-js-d3v4"
 
 crossScalaVersions := Seq("2.12.12", "2.13.3")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.6
+sbt.version=1.4.7

--- a/src/main/scala/D3.scala
+++ b/src/main/scala/D3.scala
@@ -18,6 +18,7 @@ package d3v4 {
     @inline implicit def d3toD3Quadtree(d3t: d3.type): d3quadtree.type = d3quadtree
     @inline implicit def d3toD3Zoom(d3t: d3.type): d3zoom.type = d3zoom
     @inline implicit def d3toD3Transition(d3t: d3.type): d3transition.type = d3transition
+    @inline implicit def d3toD3Hierarchy(d3t: d3.type): d3hierarchy.type = d3hierarchy
 
     @js.native
     trait BaseEvent extends js.Object {

--- a/src/main/scala/D3.scala
+++ b/src/main/scala/D3.scala
@@ -40,7 +40,7 @@ package d3v4 {
     type Quadtree[Datum] = d3quadtree.Quadtree[Datum]
     type QuadtreeNode[Datum] = d3quadtree.QuadtreeNode[Datum]
     type Transition[Datum] = d3transition.Transition[Datum]
-    type Hierarchy[N <: HierarchyNode] = d3hierarchy.Hierarchy[N]
+    type Hierarchy[N <: HierarchyNode[N]] = d3hierarchy.Hierarchy[N]
   }
 }
 

--- a/src/main/scala/D3.scala
+++ b/src/main/scala/D3.scala
@@ -40,7 +40,7 @@ package d3v4 {
     type Quadtree[Datum] = d3quadtree.Quadtree[Datum]
     type QuadtreeNode[Datum] = d3quadtree.QuadtreeNode[Datum]
     type Transition[Datum] = d3transition.Transition[Datum]
-    type Hierarchy[N <: HierarchyNode[N]] = d3hierarchy.Hierarchy[N]
+    type Hierarchy[Datum] = d3hierarchy.Hierarchy[Datum]
   }
 }
 

--- a/src/main/scala/D3.scala
+++ b/src/main/scala/D3.scala
@@ -40,6 +40,7 @@ package d3v4 {
     type Quadtree[Datum] = d3quadtree.Quadtree[Datum]
     type QuadtreeNode[Datum] = d3quadtree.QuadtreeNode[Datum]
     type Transition[Datum] = d3transition.Transition[Datum]
+    type Hierarchy[N <: HierarchyNode] = d3hierarchy.Hierarchy[N]
   }
 }
 

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -82,7 +82,7 @@ object d3hierarchy extends js.Object {
   }
 
   @js.native
-  trait Packed extends js.Object {
+  trait Packed extends js.Object { self: Hierarchy[_] =>
     def x: js.UndefOr[Double] = js.native
     def y: js.UndefOr[Double] = js.native
     def r: js.UndefOr[Double] = js.native

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -1,6 +1,5 @@
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSExportAll, JSImport}
-import d3hierarchy.Hierarchy
 
 /**
  * @see [[https://github.com/d3/d3-hierarchy]]
@@ -12,102 +11,146 @@ import d3hierarchy.Hierarchy
 object d3hierarchy extends js.Object {
 
   /** @see [[https://github.com/d3/d3-hierarchy#hierarchy]] */
-  def hierarchy[Datum](data: Datum): Hierarchy[Datum] = js.native
+  def hierarchy[N <: HierarchyNode](data: N): Hierarchy[N] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#hierarchy]] */
-  def hierarchy[Datum](data: Datum, children: js.Function1[Datum, js.Array[Datum]]): Hierarchy[Datum] = js.native
+  def hierarchy[N <: HierarchyNode](data: N, children: js.Function1[N, js.Array[N]]): Hierarchy[N] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack]] */
-  def pack[Datum](): Pack[Datum] = js.native
+  def pack[N <: HierarchyNode with PackNode](): Pack[N] = js.native
 
   @js.native
-  trait Hierarchy[Datum] extends js.Object {
-
-    def data: Datum = js.native
-    def depth: Int = js.native
-    def height: Int = js.native
-    def parent: Hierarchy[Datum] = js.native
-    def children: js.Array[Hierarchy[Datum]] = js.native
-    //def value: ??? = js.native
+  trait Hierarchy[N <: HierarchyNode] extends js.Object {
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_ancestors]] */
-    def ancestors(): js.Array[Hierarchy[Datum]] = js.native
+    def ancestors(): js.Array[N] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_descendants]] */
-    def descendants(): js.Array[Hierarchy[Datum]] = js.native
+    def descendants(): js.Array[N] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_leaves]] */
-    def leaves(): js.Array[Hierarchy[Datum]] = js.native
+    def leaves(): js.Array[N] = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_find]] */
-    //def find(filter: ???): js.UndefOr[Node[Datum]] = js.native
+    //def find(filter: ???): js.UndefOr[N] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_path]] */
-    def path(target: Hierarchy[Datum]): js.Array[Hierarchy[Datum]] = js.native
+    def path(target: N): js.Array[N] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_links]] */
-    def links(): js.Array[Hierarchy[Datum]] = js.native
+    def links(): js.Array[N] = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_sum]] */
-    //def sum(value: ???): js.Array[Node[Datum]] = js.native
+    //def sum(value: ???): js.Array[N] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_count]] */
     def count(): Int = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_sort]] */
-    def sort(compare: js.Function2[Hierarchy[Datum], Hierarchy[Datum], Int]): Hierarchy[Datum] = js.native
+    def sort(compare: js.Function2[N, N, Int]): this.type = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_each]] */
-    def each(function: js.Function1[Hierarchy[Datum], Unit]):Hierarchy[Datum] = js.native
+    def each(function: js.Function1[N, Unit]): this.type = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_each]] */
-    //def each(function: js.Function1[Node[Datum], Unit], that: ???):Node[Datum] = js.native
+    //def each(function: js.Function1[N, Unit], that: ???): this.type = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_eachAfter]] */
-    def eachAfter(function: js.Function1[Hierarchy[Datum], Unit]):Hierarchy[Datum] = js.native
+    def eachAfter(function: js.Function1[N, Unit]): this.type = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_eachAfter]] */
-    //def eachAfter(function: js.Function1[Node[Datum], Unit], that: ???):Node[Datum] = js.native
+    //def eachAfter(function: js.Function1[N, Unit], that: ???): this.type = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_eachBefore]] */
-    def eachBefore(function: js.Function1[Hierarchy[Datum], Unit]):Hierarchy[Datum] = js.native
+    def eachBefore(function: js.Function1[N, Unit]): this.type = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_eachBefore]] */
-    //def eachBefore(function: js.Function1[Node[Datum], Unit], that: ???):Node[Datum] = js.native
+    //def eachBefore(function: js.Function1[N, Unit], that: ???): this.type = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_copy]] */
-    def copy(): Hierarchy[Datum] = js.native
+    def copy(): this.type = js.native
 
   }
 
 }
 
+@JSExportAll
+trait HierarchyNode {
+
+  //def data: js.UndefOr[Datum]
+  //def data_=(newData:js.UndefOr[Datum] ): Unit
+
+  def depth: js.UndefOr[Int]
+  def depth_=(newDepth: js.UndefOr[Int]): js.UndefOr[Int]
+
+  def height: js.UndefOr[Int]
+  def height_=(newHeight: js.UndefOr[Int]): Unit
+
+  def parent: js.UndefOr[this.type]
+  def parent_=(newParent: js.UndefOr[this.type]): Unit
+
+  def children: js.UndefOr[js.Array[this.type]]
+  def children_=(newChildren: js.UndefOr[js.Array[this.type]]): Unit
+
+  //def value: ???
+  //def value_=(newValue: ???): Unit
+
+}
+
+trait HierarchyNodeImpl extends HierarchyNode {
+  //override var data = js.undefined
+  override var depth = js.undefined
+  override var height = js.undefined
+  override var parent = js.undefined
+  override var children = js.undefined
+}
+
+@JSExportAll
+trait PackNode {
+
+  def x: js.UndefOr[Double]
+  def x_=(newX: js.UndefOr[Double]): Unit
+
+  def y: js.UndefOr[Double]
+  def y_=(newY: js.UndefOr[Double]): Unit
+
+  def r: js.UndefOr[Double]
+  def r_=(newR: js.UndefOr[Double]): Unit
+
+}
+
+trait PackNodeImpl extends PackNode {
+  override var x = js.undefined
+  override var y = js.undefined
+  override var r = js.undefined
+}
+
 /** @see [[https://github.com/d3/d3-hierarchy#pack]] */
 @JSExportAll
-trait Pack[Datum] extends js.Function1[Hierarchy[Datum], Hierarchy[Datum]] {
+trait Pack[N <: HierarchyNode with PackNode] extends js.Function1[N, N] {
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
   def radius(): Double = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
-  def radius(radius: js.Function1[Hierarchy[Datum], Double]): Pack[Datum] = js.native
+  def radius(radius: js.Function1[N, Double]): this.type = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
-  def radius(radius: Double): Pack[Datum] = js.native
+  def radius(radius: Double): this.type = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack_size]] */
   def size(): js.Array[Int] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack_size]] */
-  def size(size: js.Array[Int]): Pack[Datum] = js.native
+  def size(size: js.Array[Int]): this.type = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
-  def padding(): js.Function1[Hierarchy[Datum], Double] = js.native
+  def padding(): js.Function1[N, Double] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
-  def padding(padding: js.Function1[Hierarchy[Datum], Double]): Pack[Datum] = js.native
+  def padding(padding: js.Function1[N, Double]): this.type = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
-  def padding(padding:  Double): Pack[Datum] = js.native
+  def padding(padding: Double): this.type = js.native
 
 }

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -16,6 +16,9 @@ object d3hierarchy extends js.Object {
   /** @see [[https://github.com/d3/d3-hierarchy#hierarchy]] */
   def hierarchy[Datum](data: Datum, children: js.Function1[Datum, js.Array[Datum]]): Node[Datum] = js.native
 
+  /** @see [[https://github.com/d3/d3-hierarchy#pack]] */
+  def pack[Datum](): Pack[Datum] = js.native
+
   @js.native
   trait Node[Datum] extends js.Object {
 
@@ -75,5 +78,37 @@ object d3hierarchy extends js.Object {
     def copy(): Node[Datum] = js.native
 
   }
+
+}
+
+import d3hierarchy.Node
+
+/** @see [[https://github.com/d3/d3-hierarchy#pack]] */
+@JSExportAll
+trait Pack[Datum] extends js.Function1[Node[Datum], Node[Datum]] {
+
+  /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
+  def radius(): Double = js.native
+
+  /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
+  def radius(radius: js.Function1[Node[Datum], Double]): Pack[Datum] = js.native
+
+  /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
+  def radius(radius: Double): Pack[Datum] = js.native
+
+  /** @see [[https://github.com/d3/d3-hierarchy#pack_size]] */
+  def size(): js.Array[Int] = js.native
+
+  /** @see [[https://github.com/d3/d3-hierarchy#pack_size]] */
+  def size(size: js.Array[Int]): Pack[Datum] = js.native
+
+  /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
+  def padding(): js.Function1[Node[Datum], Double] = js.native
+
+  /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
+  def padding(padding: js.Function1[Node[Datum], Double]): Pack[Datum] = js.native
+
+  /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
+  def padding(padding:  Double): Pack[Datum] = js.native
 
 }

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -16,7 +16,7 @@ object d3hierarchy extends js.Object {
   def hierarchy[N <: HierarchyNode](data: N): Hierarchy[N] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#hierarchy]] */
-  def hierarchy[N <: HierarchyNode](data: N, children: js.Function1[N, js.Array[N]]): Hierarchy[N] = js.native
+  def hierarchy[N <: HierarchyNode](data: N, children: js.Function1[N, js.UndefOr[js.Array[N]]]): Hierarchy[N] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack]] */
   def pack[N <: HierarchyNode with PackNode](): Pack[N] = js.native

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -18,10 +18,62 @@ object d3hierarchy extends js.Object {
 
   @js.native
   trait Node[Datum] extends js.Object {
+
     def data: Datum = js.native
     def depth: Int = js.native
     def height: Int = js.native
     def parent: Node[Datum] = js.native
+    def children: js.Array[Datum] = js.native
+    //def value: ??? = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#node_ancestors]] */
+    def ancestors(): js.Array[Node[Datum]] = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#node_descendants]] */
+    def descendants(): js.Array[Node[Datum]] = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#node_leaves]] */
+    def leaves(): js.Array[Node[Datum]] = js.native
+
+    ///** @see [[https://github.com/d3/d3-hierarchy#node_find]] */
+    //def find(filter: ???): js.UndefOr[Node[Datum]] = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#node_path]] */
+    def path(target: Node[Datum]): js.Array[Node[Datum]] = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#node_links]] */
+    def links(): js.Array[Node[Datum]] = js.native
+
+    ///** @see [[https://github.com/d3/d3-hierarchy#node_sum]] */
+    //def sum(value: ???): js.Array[Node[Datum]] = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#node_count]] */
+    def count(): Int = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#node_sort]] */
+    def sort(compare: js.Function2[Node[Datum], Node[Datum], Int]): Node[Datum] = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#node_each]] */
+    def each(function: js.Function1[Node[Datum], Unit]):Node[Datum] = js.native
+
+    ///** @see [[https://github.com/d3/d3-hierarchy#node_each]] */
+    //def each(function: js.Function1[Node[Datum], Unit], that: ???):Node[Datum] = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#node_eachAfter]] */
+    def eachAfter(function: js.Function1[Node[Datum], Unit]):Node[Datum] = js.native
+
+    ///** @see [[https://github.com/d3/d3-hierarchy#node_eachAfter]] */
+    //def eachAfter(function: js.Function1[Node[Datum], Unit], that: ???):Node[Datum] = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#node_eachBefore]] */
+    def eachBefore(function: js.Function1[Node[Datum], Unit]):Node[Datum] = js.native
+
+    ///** @see [[https://github.com/d3/d3-hierarchy#node_eachBefore]] */
+    //def eachBefore(function: js.Function1[Node[Datum], Unit], that: ???):Node[Datum] = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#node_copy]] */
+    def copy(): Node[Datum] = js.native
+
   }
 
 }

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -80,7 +80,7 @@ object d3hierarchy extends js.Object {
    * @see [[https://github.com/d3/d3-hierarchy#pack]]
    */
   @js.native
-  trait Pack[N <: HierarchyNode with PackNode] extends js.Function1[N, N] {
+  trait Pack[N <: HierarchyNode with PackNode] extends js.Function1[Hierarchy[N], Hierarchy[N]] {
 
     /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
     def radius(): Double = js.native

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -11,7 +11,10 @@ import scala.scalajs.js.annotation._
 object d3hierarchy extends js.Object {
 
   /** @see [[https://github.com/d3/d3-hierarchy#hierarchy]] */
-  def hierarchy[Datum](data:Datum): Node[Datum] = js.native
+  def hierarchy[Datum](data: Datum): Node[Datum] = js.native
+
+  /** @see [[https://github.com/d3/d3-hierarchy#hierarchy]] */
+  def hierarchy[Datum](data: Datum, children: js.Function1[Datum, js.Array[Datum]]): Node[Datum] = js.native
 
   @js.native
   trait Node[Datum] extends js.Object {
@@ -22,5 +25,3 @@ object d3hierarchy extends js.Object {
   }
 
 }
-
-

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -1,5 +1,6 @@
 import scala.scalajs.js
-import scala.scalajs.js.annotation._
+import scala.scalajs.js.annotation.{JSExportAll, JSImport}
+import d3hierarchy.Hierarchy
 
 /**
  * @see [[https://github.com/d3/d3-hierarchy]]
@@ -11,41 +12,41 @@ import scala.scalajs.js.annotation._
 object d3hierarchy extends js.Object {
 
   /** @see [[https://github.com/d3/d3-hierarchy#hierarchy]] */
-  def hierarchy[Datum](data: Datum): Node[Datum] = js.native
+  def hierarchy[Datum](data: Datum): Hierarchy[Datum] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#hierarchy]] */
-  def hierarchy[Datum](data: Datum, children: js.Function1[Datum, js.Array[Datum]]): Node[Datum] = js.native
+  def hierarchy[Datum](data: Datum, children: js.Function1[Datum, js.Array[Datum]]): Hierarchy[Datum] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack]] */
   def pack[Datum](): Pack[Datum] = js.native
 
   @js.native
-  trait Node[Datum] extends js.Object {
+  trait Hierarchy[Datum] extends js.Object {
 
     def data: Datum = js.native
     def depth: Int = js.native
     def height: Int = js.native
-    def parent: Node[Datum] = js.native
-    def children: js.Array[Datum] = js.native
+    def parent: Hierarchy[Datum] = js.native
+    def children: js.Array[Hierarchy[Datum]] = js.native
     //def value: ??? = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_ancestors]] */
-    def ancestors(): js.Array[Node[Datum]] = js.native
+    def ancestors(): js.Array[Hierarchy[Datum]] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_descendants]] */
-    def descendants(): js.Array[Node[Datum]] = js.native
+    def descendants(): js.Array[Hierarchy[Datum]] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_leaves]] */
-    def leaves(): js.Array[Node[Datum]] = js.native
+    def leaves(): js.Array[Hierarchy[Datum]] = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_find]] */
     //def find(filter: ???): js.UndefOr[Node[Datum]] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_path]] */
-    def path(target: Node[Datum]): js.Array[Node[Datum]] = js.native
+    def path(target: Hierarchy[Datum]): js.Array[Hierarchy[Datum]] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_links]] */
-    def links(): js.Array[Node[Datum]] = js.native
+    def links(): js.Array[Hierarchy[Datum]] = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_sum]] */
     //def sum(value: ???): js.Array[Node[Datum]] = js.native
@@ -54,44 +55,42 @@ object d3hierarchy extends js.Object {
     def count(): Int = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_sort]] */
-    def sort(compare: js.Function2[Node[Datum], Node[Datum], Int]): Node[Datum] = js.native
+    def sort(compare: js.Function2[Hierarchy[Datum], Hierarchy[Datum], Int]): Hierarchy[Datum] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_each]] */
-    def each(function: js.Function1[Node[Datum], Unit]):Node[Datum] = js.native
+    def each(function: js.Function1[Hierarchy[Datum], Unit]):Hierarchy[Datum] = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_each]] */
     //def each(function: js.Function1[Node[Datum], Unit], that: ???):Node[Datum] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_eachAfter]] */
-    def eachAfter(function: js.Function1[Node[Datum], Unit]):Node[Datum] = js.native
+    def eachAfter(function: js.Function1[Hierarchy[Datum], Unit]):Hierarchy[Datum] = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_eachAfter]] */
     //def eachAfter(function: js.Function1[Node[Datum], Unit], that: ???):Node[Datum] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_eachBefore]] */
-    def eachBefore(function: js.Function1[Node[Datum], Unit]):Node[Datum] = js.native
+    def eachBefore(function: js.Function1[Hierarchy[Datum], Unit]):Hierarchy[Datum] = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_eachBefore]] */
     //def eachBefore(function: js.Function1[Node[Datum], Unit], that: ???):Node[Datum] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_copy]] */
-    def copy(): Node[Datum] = js.native
+    def copy(): Hierarchy[Datum] = js.native
 
   }
 
 }
 
-import d3hierarchy.Node
-
 /** @see [[https://github.com/d3/d3-hierarchy#pack]] */
 @JSExportAll
-trait Pack[Datum] extends js.Function1[Node[Datum], Node[Datum]] {
+trait Pack[Datum] extends js.Function1[Hierarchy[Datum], Hierarchy[Datum]] {
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
   def radius(): Double = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
-  def radius(radius: js.Function1[Node[Datum], Double]): Pack[Datum] = js.native
+  def radius(radius: js.Function1[Hierarchy[Datum], Double]): Pack[Datum] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
   def radius(radius: Double): Pack[Datum] = js.native
@@ -103,10 +102,10 @@ trait Pack[Datum] extends js.Function1[Node[Datum], Node[Datum]] {
   def size(size: js.Array[Int]): Pack[Datum] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
-  def padding(): js.Function1[Node[Datum], Double] = js.native
+  def padding(): js.Function1[Hierarchy[Datum], Double] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
-  def padding(padding: js.Function1[Node[Datum], Double]): Pack[Datum] = js.native
+  def padding(padding: js.Function1[Hierarchy[Datum], Double]): Pack[Datum] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
   def padding(padding:  Double): Pack[Datum] = js.native

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -13,17 +13,17 @@ import scala.scalajs.js.annotation.{JSExportAll, JSImport}
 object d3hierarchy extends js.Object {
 
   /** @see [[https://github.com/d3/d3-hierarchy#hierarchy]] */
-  def hierarchy[N <: HierarchyNode](data: N): Hierarchy[N] = js.native
+  def hierarchy[N <: HierarchyNode[N]](data: N): Hierarchy[N] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#hierarchy]] */
-  def hierarchy[N <: HierarchyNode](data: N, children: js.Function1[N, js.UndefOr[js.Array[N]]]): Hierarchy[N] = js.native
+  def hierarchy[N <: HierarchyNode[N]](data: N, children: js.Function1[N, js.UndefOr[js.Array[N]]]): Hierarchy[N] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack]] */
-  def pack[N <: HierarchyNode with PackNode](): Pack[N] = js.native
+  def pack[N <: HierarchyNode[N] with PackNode](): Pack[N] = js.native
 
   /** @see [[hierarchy]] */
   @js.native
-  trait Hierarchy[N <: HierarchyNode] extends js.Object {
+  trait Hierarchy[N <: HierarchyNode[N]] extends js.Object {
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_ancestors]] */
     def ancestors(): js.Array[N] = js.native
@@ -80,7 +80,7 @@ object d3hierarchy extends js.Object {
    * @see [[https://github.com/d3/d3-hierarchy#pack]]
    */
   @js.native
-  trait Pack[N <: HierarchyNode with PackNode] extends js.Function1[Hierarchy[N], Hierarchy[N]] {
+  trait Pack[N <: HierarchyNode[N] with PackNode] extends js.Function1[Hierarchy[N], Hierarchy[N]] {
 
     /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
     def radius(): Double = js.native
@@ -111,7 +111,7 @@ object d3hierarchy extends js.Object {
 }
 
 @JSExportAll
-trait HierarchyNode {
+trait HierarchyNode[N <: HierarchyNode[N]] {
 
   //def data: js.UndefOr[Datum]
   //def data_=(newData:js.UndefOr[Datum] ): Unit
@@ -122,23 +122,23 @@ trait HierarchyNode {
   def height: js.UndefOr[Int]
   def height_=(newHeight: js.UndefOr[Int]): Unit
 
-  def parent: js.UndefOr[this.type]
-  def parent_=(newParent: js.UndefOr[this.type]): Unit
+  def parent: js.UndefOr[N]
+  def parent_=(newParent: js.UndefOr[N]): Unit
 
-  def children: js.UndefOr[js.Array[this.type]]
-  def children_=(newChildren: js.UndefOr[js.Array[this.type]]): Unit
+  def children: js.UndefOr[js.Array[N]]
+  def children_=(newChildren: js.UndefOr[js.Array[N]]): Unit
 
   //def value: ???
   //def value_=(newValue: ???): Unit
 
 }
 
-trait HierarchyNodeImpl extends HierarchyNode {
+trait HierarchyNodeImpl[N <: HierarchyNode[N]] extends HierarchyNode[N] {
   //override var data = js.undefined
   override var depth: js.UndefOr[Int] = js.undefined
   override var height: js.UndefOr[Int] = js.undefined
-  override var parent: js.UndefOr[this.type] = js.undefined
-  override var children: js.UndefOr[js.Array[this.type]] = js.undefined
+  override var parent: js.UndefOr[N] = js.undefined
+  override var children: js.UndefOr[js.Array[N]] = js.undefined
 }
 
 @JSExportAll

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -1,0 +1,26 @@
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+/**
+ * @see [[https://github.com/d3/d3-hierarchy]]
+ * @since January, 2021
+ * @author <a href="mailto:michael@ahlers.consulting">Michael Ahlers</a>
+ */
+@JSImport("d3-hierarchy", JSImport.Namespace)
+@js.native
+object d3hierarchy extends js.Object {
+
+  /** @see [[https://github.com/d3/d3-hierarchy#hierarchy]] */
+  def hierarchy[Datum](data:Datum): Node[Datum] = js.native
+
+  @js.native
+  trait Node[Datum] extends js.Object {
+    def data: Datum = js.native
+    def depth: Int = js.native
+    def height: Int = js.native
+    def parent: Node[Datum] = js.native
+  }
+
+}
+
+

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -1,3 +1,5 @@
+package d3v4
+
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSExportAll, JSImport}
 

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -19,6 +19,7 @@ object d3hierarchy extends js.Object {
   /** @see [[https://github.com/d3/d3-hierarchy#pack]] */
   def pack[N <: HierarchyNode with PackNode](): Pack[N] = js.native
 
+  /** @see [[hierarchy]] */
   @js.native
   trait Hierarchy[N <: HierarchyNode] extends js.Object {
 
@@ -72,7 +73,10 @@ object d3hierarchy extends js.Object {
 
   }
 
-  /** @see [[https://github.com/d3/d3-hierarchy#pack]] */
+  /**
+   * @see [[pack]]
+   * @see [[https://github.com/d3/d3-hierarchy#pack]]
+   */
   @js.native
   trait Pack[N <: HierarchyNode with PackNode] extends js.Function1[N, N] {
 

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -145,15 +145,12 @@ trait HierarchyNodeImpl extends HierarchyNode {
 trait PackNode {
 
   def x: js.UndefOr[Double]
-
   def x_=(newX: js.UndefOr[Double]): Unit
 
   def y: js.UndefOr[Double]
-
   def y_=(newY: js.UndefOr[Double]): Unit
 
   def r: js.UndefOr[Double]
-
   def r_=(newR: js.UndefOr[Double]): Unit
 
 }

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -72,6 +72,36 @@ object d3hierarchy extends js.Object {
 
   }
 
+  /** @see [[https://github.com/d3/d3-hierarchy#pack]] */
+  @js.native
+  trait Pack[N <: HierarchyNode with PackNode] extends js.Function1[N, N] {
+
+    /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
+    def radius(): Double = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
+    def radius(radius: js.Function1[N, Double]): this.type = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
+    def radius(radius: Double): this.type = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#pack_size]] */
+    def size(): js.Array[Int] = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#pack_size]] */
+    def size(size: js.Array[Int]): this.type = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
+    def padding(): js.Function1[N, Double] = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
+    def padding(padding: js.Function1[N, Double]): this.type = js.native
+
+    /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
+    def padding(padding: Double): this.type = js.native
+
+  }
+
 }
 
 @JSExportAll
@@ -81,7 +111,7 @@ trait HierarchyNode {
   //def data_=(newData:js.UndefOr[Datum] ): Unit
 
   def depth: js.UndefOr[Int]
-  def depth_=(newDepth: js.UndefOr[Int]): js.UndefOr[Int]
+  def depth_=(newDepth: js.UndefOr[Int]): Unit
 
   def height: js.UndefOr[Int]
   def height_=(newHeight: js.UndefOr[Int]): Unit
@@ -99,58 +129,31 @@ trait HierarchyNode {
 
 trait HierarchyNodeImpl extends HierarchyNode {
   //override var data = js.undefined
-  override var depth = js.undefined
-  override var height = js.undefined
-  override var parent = js.undefined
-  override var children = js.undefined
+  override var depth: js.UndefOr[Int] = js.undefined
+  override var height: js.UndefOr[Int] = js.undefined
+  override var parent: js.UndefOr[this.type] = js.undefined
+  override var children: js.UndefOr[js.Array[this.type]] = js.undefined
 }
 
 @JSExportAll
 trait PackNode {
 
   def x: js.UndefOr[Double]
+
   def x_=(newX: js.UndefOr[Double]): Unit
 
   def y: js.UndefOr[Double]
+
   def y_=(newY: js.UndefOr[Double]): Unit
 
   def r: js.UndefOr[Double]
+
   def r_=(newR: js.UndefOr[Double]): Unit
 
 }
 
 trait PackNodeImpl extends PackNode {
-  override var x = js.undefined
-  override var y = js.undefined
-  override var r = js.undefined
-}
-
-/** @see [[https://github.com/d3/d3-hierarchy#pack]] */
-@JSExportAll
-trait Pack[N <: HierarchyNode with PackNode] extends js.Function1[N, N] {
-
-  /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
-  def radius(): Double = js.native
-
-  /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
-  def radius(radius: js.Function1[N, Double]): this.type = js.native
-
-  /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
-  def radius(radius: Double): this.type = js.native
-
-  /** @see [[https://github.com/d3/d3-hierarchy#pack_size]] */
-  def size(): js.Array[Int] = js.native
-
-  /** @see [[https://github.com/d3/d3-hierarchy#pack_size]] */
-  def size(size: js.Array[Int]): this.type = js.native
-
-  /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
-  def padding(): js.Function1[N, Double] = js.native
-
-  /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
-  def padding(padding: js.Function1[N, Double]): this.type = js.native
-
-  /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
-  def padding(padding: Double): this.type = js.native
-
+  override var x: js.UndefOr[Double] = js.undefined
+  override var y: js.UndefOr[Double] = js.undefined
+  override var r: js.UndefOr[Double] = js.undefined
 }

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -13,19 +13,19 @@ import scala.scalajs.js.annotation.{JSExportAll, JSImport}
 object d3hierarchy extends js.Object {
 
   /** @see [[https://github.com/d3/d3-hierarchy#hierarchy]] */
-  def hierarchy[N <: HierarchyNode[N]](data: N): Hierarchy[N] = js.native
+  def hierarchy[Datum](data: Datum): Hierarchy[Datum] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#hierarchy]] */
-  def hierarchy[N <: HierarchyNode[N]](data: N, children: js.Function1[N, js.UndefOr[js.Array[N]]]): Hierarchy[N] = js.native
+  def hierarchy[Datum](data: Datum, children: js.Function1[Datum, js.UndefOr[js.Array[Datum]]]): Hierarchy[Datum] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack]] */
-  def pack[N <: HierarchyNode[N] with PackNode](): Pack[N] = js.native
+  def pack[Datum](): Pack[Datum] = js.native
 
   /** @see [[hierarchy]] */
   @js.native
-  trait Hierarchy[N <: HierarchyNode[N]] extends js.Object {
+  trait Hierarchy[Datum] extends js.Object {
 
-    def data: N = js.native
+    def data: Datum = js.native
     def depth: js.UndefOr[Int] = js.native
     def height: js.UndefOr[Int] = js.native
     def parent: js.UndefOr[this.type] = js.native
@@ -44,7 +44,7 @@ object d3hierarchy extends js.Object {
     //def find(filter: ???): ??? = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_path]] */
-    def path(target: N): js.Array[this.type] = js.native
+    def path(target: Datum): js.Array[this.type] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_links]] */
     def links(): js.Array[this.type] = js.native
@@ -81,18 +81,25 @@ object d3hierarchy extends js.Object {
 
   }
 
+  @js.native
+  trait Packed extends js.Object {
+    def x: js.UndefOr[Double] = js.native
+    def y: js.UndefOr[Double] = js.native
+    def r: js.UndefOr[Double] = js.native
+  }
+
   /**
    * @see [[pack]]
    * @see [[https://github.com/d3/d3-hierarchy#pack]]
    */
   @js.native
-  trait Pack[N <: HierarchyNode[N] with PackNode] extends js.Function1[Hierarchy[N], Hierarchy[N]] {
+  trait Pack[Datum] extends js.Function1[Hierarchy[Datum], Hierarchy[Datum] with Packed] {
 
     /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
     def radius(): Double = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
-    def radius(radius: js.Function1[N, js.UndefOr[Double]]): this.type = js.native
+    def radius(radius: js.Function1[Hierarchy[Datum], js.UndefOr[Double]]): this.type = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
     //def radius(radius: Double): this.type = js.native
@@ -104,10 +111,10 @@ object d3hierarchy extends js.Object {
     def size(size: js.Array[Int]): this.type = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
-    def padding(): js.Function1[N, Double] = js.native
+    def padding(): js.Function1[Hierarchy[Datum], Double] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
-    def padding(padding: js.Function1[N, Double]): this.type = js.native
+    def padding(padding: js.Function1[Hierarchy[Datum], Double]): this.type = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#pack_padding]] */
     def padding(padding: Double): this.type = js.native
@@ -116,53 +123,3 @@ object d3hierarchy extends js.Object {
 
 }
 
-@JSExportAll
-trait HierarchyNode[N <: HierarchyNode[N]] {
-
-  //def data: js.UndefOr[Datum]
-  //def data_=(newData:js.UndefOr[Datum] ): Unit
-
-  def depth: js.UndefOr[Int]
-  def depth_=(newDepth: js.UndefOr[Int]): Unit
-
-  def height: js.UndefOr[Int]
-  def height_=(newHeight: js.UndefOr[Int]): Unit
-
-  def parent: js.UndefOr[N]
-  def parent_=(newParent: js.UndefOr[N]): Unit
-
-  def children: js.UndefOr[js.Array[N]]
-  def children_=(newChildren: js.UndefOr[js.Array[N]]): Unit
-
-  //def value: ???
-  //def value_=(newValue: ???): Unit
-
-}
-
-trait HierarchyNodeImpl[N <: HierarchyNode[N]] extends HierarchyNode[N] {
-  //override var data = js.undefined
-  override var depth: js.UndefOr[Int] = js.undefined
-  override var height: js.UndefOr[Int] = js.undefined
-  override var parent: js.UndefOr[N] = js.undefined
-  override var children: js.UndefOr[js.Array[N]] = js.undefined
-}
-
-@JSExportAll
-trait PackNode {
-
-  def x: js.UndefOr[Double]
-  def x_=(newX: js.UndefOr[Double]): Unit
-
-  def y: js.UndefOr[Double]
-  def y_=(newY: js.UndefOr[Double]): Unit
-
-  def r: js.UndefOr[Double]
-  def r_=(newR: js.UndefOr[Double]): Unit
-
-}
-
-trait PackNodeImpl extends PackNode {
-  override var x: js.UndefOr[Double] = js.undefined
-  override var y: js.UndefOr[Double] = js.undefined
-  override var r: js.UndefOr[Double] = js.undefined
-}

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -25,50 +25,56 @@ object d3hierarchy extends js.Object {
   @js.native
   trait Hierarchy[N <: HierarchyNode[N]] extends js.Object {
 
+    def data: N = js.native
+    def depth: js.UndefOr[Int] = js.native
+    def height: js.UndefOr[Int] = js.native
+    def parent: js.UndefOr[this.type] = js.native
+    def children: js.UndefOr[js.Array[this.type]] = js.native
+
     /** @see [[https://github.com/d3/d3-hierarchy#node_ancestors]] */
-    def ancestors(): js.Array[N] = js.native
+    def ancestors(): js.Array[this.type] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_descendants]] */
-    def descendants(): js.Array[N] = js.native
+    def descendants(): js.Array[this.type] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_leaves]] */
-    def leaves(): js.Array[N] = js.native
+    def leaves(): js.Array[this.type] = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_find]] */
-    //def find(filter: ???): js.UndefOr[N] = js.native
+    //def find(filter: ???): ??? = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_path]] */
-    def path(target: N): js.Array[N] = js.native
+    def path(target: N): js.Array[this.type] = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_links]] */
-    def links(): js.Array[N] = js.native
+    def links(): js.Array[this.type] = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_sum]] */
-    //def sum(value: ???): js.Array[N] = js.native
+    //def sum(value: ???): ??? = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_count]] */
     def count(): Int = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_sort]] */
-    def sort(compare: js.Function2[N, N, Int]): this.type = js.native
+    def sort(compare: js.Function2[this.type, this.type, Int]): this.type = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_each]] */
-    def each(function: js.Function1[N, Unit]): this.type = js.native
+    def each(function: js.Function1[this.type, Unit]): this.type = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_each]] */
-    //def each(function: js.Function1[N, Unit], that: ???): this.type = js.native
+    //def each(function: js.Function1[this.type, Unit], that: ???): this.type = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_eachAfter]] */
-    def eachAfter(function: js.Function1[N, Unit]): this.type = js.native
+    def eachAfter(function: js.Function1[this.type, Unit]): this.type = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_eachAfter]] */
-    //def eachAfter(function: js.Function1[N, Unit], that: ???): this.type = js.native
+    //def eachAfter(function: js.Function1[this.type, Unit], that: ???): this.type = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_eachBefore]] */
-    def eachBefore(function: js.Function1[N, Unit]): this.type = js.native
+    def eachBefore(function: js.Function1[this.type, Unit]): this.type = js.native
 
     ///** @see [[https://github.com/d3/d3-hierarchy#node_eachBefore]] */
-    //def eachBefore(function: js.Function1[N, Unit], that: ???): this.type = js.native
+    //def eachBefore(function: js.Function1[this.type, Unit], that: ???): this.type = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#node_copy]] */
     def copy(): this.type = js.native

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -86,10 +86,10 @@ object d3hierarchy extends js.Object {
     def radius(): Double = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
-    def radius(radius: js.Function1[N, Double]): this.type = js.native
+    def radius(radius: js.Function1[N, js.UndefOr[Double]]): this.type = js.native
 
-    /** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
-    def radius(radius: Double): this.type = js.native
+    ///** @see [[https://github.com/d3/d3-hierarchy#pack_radius]] */
+    //def radius(radius: Double): this.type = js.native
 
     /** @see [[https://github.com/d3/d3-hierarchy#pack_size]] */
     def size(): js.Array[Int] = js.native

--- a/src/main/scala/Hierarchy.scala
+++ b/src/main/scala/Hierarchy.scala
@@ -16,7 +16,7 @@ object d3hierarchy extends js.Object {
   def hierarchy[Datum](data: Datum): Hierarchy[Datum] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#hierarchy]] */
-  def hierarchy[Datum](data: Datum, children: js.Function1[Datum, js.UndefOr[js.Array[Datum]]]): Hierarchy[Datum] = js.native
+  def hierarchy[Datum](data: Datum, children: js.Function1[Datum, js.Array[Datum]]): Hierarchy[Datum] = js.native
 
   /** @see [[https://github.com/d3/d3-hierarchy#pack]] */
   def pack[Datum](): Pack[Datum] = js.native


### PR DESCRIPTION
To illustrate usage:

```scala
case class Datum(name: String, children: Datum*)

val data: Datum =
  Datum(
    "Root",
    Datum("Child 1"),
    Datum("Child 2"))

val hierarchy: Hierarchy[Datum] =
  d3.hierarchy[Datum](data, (_: Datum).children.toJSArray)
    // Type ascription here is only for clarification.
    .each { node: Hierarchy[Datum] =>
      println(s"""name = "%s", depth = %d"""
        .format(
          node.data.name,
          node.depth))
    }

d3.pack[Datum]()
  .size(js.Array(200, 100))
  .padding(_ => 2d)
  .radius(_ => 10d)
  .apply(hierarchy)
  // Type ascription here is only for clarification.
  .each { node: Hierarchy[Datum] with Packed =>
    println(s"""name = "%s", depth = %d, x = %d, y = %d, r = %d"""
      .format(
        node.data.name,
        node.depth,
        node.x,
        node.y,
        node.r))
  }
```

Output:

```
name = "Root", depth = 0
name = "Child 1", depth = 1
name = "Child 2", depth = 1
name = "Root", depth = 0, x = 100, y = 50, r = 23
name = "Child 1", depth = 1, x = 89, y = 50, r = 10
name = "Child 2", depth = 1, x = 111, y = 50, r = 10
```