### PR TITLE
Update line definition.

### DIFF
--- a/src/main/scala/Shape.scala
+++ b/src/main/scala/Shape.scala
@@ -37,7 +37,7 @@ object d3shape extends js.Object {
 
   @js.native
   trait LineGenerator extends BaseLineGenerator[LineGenerator] {
-    def apply(data: js.Array[js.Tuple2[Double, Double]]): String = js.native
+    def apply(data: js.Array[js.Tuple2[Double, Double]]): js.UndefOr[String] = js.native
   }
 
   @js.native


### PR DESCRIPTION
Per devdocs, If context is specified, sets the context and returns this line generator. If context is not specified, returns the current context, which defaults to null. If the context is not null, then the [generated line](https://devdocs.io/d3~4/d3-shape#_line) is rendered to this context as a sequence of [path method](https://www.w3.org/TR/2dcontext/#canvaspathmethods) calls. Otherwise, a [path data](https://www.w3.org/TR/SVG/paths.html#PathData) string representing the generated line is returned.

This causes an issue where the code will fail to return a String when the context is specified causing a type error. The pull request contains a fix to return a js.UndefOr[String] rather than a String which fixes the issue.